### PR TITLE
fix(deps): update peer deps to v5

### DIFF
--- a/libs/data-layer/package.json
+++ b/libs/data-layer/package.json
@@ -16,7 +16,7 @@
   "peerDependencies": {
     "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "@ng-maps/core": "^3.0.0 || ^4.0.0"
+    "@ng-maps/core": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "homepage": "https://ng-maps.github.io/kml-layer",
   "license": "MIT",

--- a/libs/drawing-layer/package.json
+++ b/libs/drawing-layer/package.json
@@ -4,7 +4,7 @@
   "peerDependencies": {
     "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "@ng-maps/core": "^3.0.0 || ^4.0.0"
+    "@ng-maps/core": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/libs/google/package.json
+++ b/libs/google/package.json
@@ -26,7 +26,7 @@
     "@angular/common": "^14.0.0  || ^15.0.0 || ^16.0.0",
     "@angular/core": "^14.0.0  || ^15.0.0 || ^16.0.0",
     "@types/google.maps": "~3.51.0 || ~3.53.0",
-    "@ng-maps/core": "^4.0.0"
+    "@ng-maps/core": "^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "tslib": "^2.0.0"

--- a/libs/here/package.json
+++ b/libs/here/package.json
@@ -28,7 +28,7 @@
   "peerDependencies": {
     "@angular/common": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^16.0.0",
     "@angular/core": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^16.0.0",
-    "@ng-maps/core": "^2.0.0-alpha.7 || ^4.0.0",
+    "@ng-maps/core": "^2.0.0-alpha.7 || ^4.0.0 || ^5.0.0",
     "@types/heremaps": "^3.1.1"
   },
   "dependencies": {

--- a/libs/kml-layer/package.json
+++ b/libs/kml-layer/package.json
@@ -18,7 +18,7 @@
   "peerDependencies": {
     "@angular/common": "^8.0.0 || ^16.0.0",
     "@angular/core": "^8.0.0 || ^16.0.0",
-    "@ng-maps/core": "^1.0.0 || ^4.0.0"
+    "@ng-maps/core": "^1.0.0 || ^4.0.0 || ^5.0.0"
   },
   "homepage": "https://ng-maps.github.io/kml-layer",
   "license": "MIT",

--- a/libs/marker-clusterer/package.json
+++ b/libs/marker-clusterer/package.json
@@ -17,8 +17,8 @@
   "peerDependencies": {
     "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "@ng-maps/core": "^4.0.0",
-    "@ng-maps/google": "^4.0.0",
+    "@ng-maps/core": "^4.0.0 || ^5.0.0",
+    "@ng-maps/google": "^4.0.0 || ^5.0.0",
     "@googlemaps/markerclusterer": "^2.0.0"
   },
   "homepage": "https://ng-maps.github.io/marker-clusterer",

--- a/libs/places/package.json
+++ b/libs/places/package.json
@@ -17,8 +17,8 @@
   "peerDependencies": {
     "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "@ng-maps/core": "^4.0.0",
-    "@ng-maps/google": "^4.0.0"
+    "@ng-maps/core": "^4.0.0 || ^5.0.0",
+    "@ng-maps/google": "^4.0.0 || ^5.0.0"
   },
   "homepage": "https://ng-maps.github.io/places",
   "license": "MIT",

--- a/libs/snazzy-info-window/package.json
+++ b/libs/snazzy-info-window/package.json
@@ -23,7 +23,7 @@
   "peerDependencies": {
     "@angular/common": "^14.0.0 || ^15.0.0 || ^16.0.0",
     "@angular/core": "^14.0.0 || ^15.0.0 || ^16.0.0",
-    "@ng-maps/core": "^4.0.0",
+    "@ng-maps/core": "^4.0.0 || ^5.0.0",
     "snazzy-info-window": "^1.1.0"
   },
   "dependencies": {


### PR DESCRIPTION
Update peer dependencies in all packages to allow `ng-maps v5` install

-----

fixes #139 