### PR TITLE
Fix documentation to change Google maps types

### DIFF
--- a/libs/core/README.md
+++ b/libs/core/README.md
@@ -9,8 +9,8 @@
 
 Then you will need to install typings for google maps as a dev dependency
 
-- Npm: `npm install -D @types/googlemaps`
-- Yarn: `yarn add -D @types/googlemaps`
+- Npm: `npm install -D @types/google.maps`
+- Yarn: `yarn add -D @types/google.maps`
 
 Add `NgMapsCoreModule` to your _AppModule_.
 

--- a/libs/google/README.md
+++ b/libs/google/README.md
@@ -9,8 +9,8 @@
 
 Then you will need to install typings for google maps as a dev dependency
 
-- Npm: `npm install -D @types/googlemaps`
-- Yarn: `yarn add -D @types/googlemaps`
+- Npm: `npm install -D @types/google.maps`
+- Yarn: `yarn add -D @types/google.maps`
 
 Add `NgMapsGoogleModule` to your _AppModule_.
 


### PR DESCRIPTION
Hello,

Following the tutorial, I get errors such as : 

```
error TS2688: Cannot find type definition file for 'google.maps'.
1 /// <reference types="google.maps" />
``` 

After some research, I discovered that the problem lies in the fact that we now have to use `@types/google.maps` instead of `@types/googlemaps` which is not explicit in the documentation.

So here is a little PR to fix the issue