### PR TITLE
feat: port polyPathChange event from agm #177

### DIFF
--- a/libs/core/src/lib/directives/polyline.ts
+++ b/libs/core/src/lib/directives/polyline.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { Subscription } from 'rxjs';
 
+import { MVCEvent } from '../interface/mvc-event';
 import { PolylineManager } from '../services/managers/polyline-manager';
 
 import { NgMapsPolylinePoint } from './polyline-point';
@@ -175,6 +176,11 @@ export class NgMapsPolyline implements OnDestroy, OnChanges, AfterContentInit {
     new EventEmitter<google.maps.PolyMouseEvent>();
 
   /**
+   * This event is fired after Polyline's path changes.
+   */
+  @Output() polyPathChange = new EventEmitter<MVCEvent<google.maps.LatLng>>();
+
+  /**
    * @internal
    */
   @ContentChildren(NgMapsPolylinePoint)
@@ -280,6 +286,13 @@ export class NgMapsPolyline implements OnDestroy, OnChanges, AfterContentInit {
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore
         .subscribe(obj.handler);
+      this.subscription.add(os);
+    });
+
+    this._polylineManager.createPathEventObservable(this).then((ob$) => {
+      const os = ob$.subscribe((pathEvent) =>
+        this.polyPathChange.emit(pathEvent),
+      );
       this.subscription.add(os);
     });
   }

--- a/libs/core/src/lib/interface/mvc-event.ts
+++ b/libs/core/src/lib/interface/mvc-event.ts
@@ -1,0 +1,8 @@
+export type MvcEventType = 'insert_at' | 'remove_at' | 'set_at';
+
+export interface MVCEvent<T> {
+  newArr: Array<T>;
+  eventName: MvcEventType;
+  index: number;
+  previous?: T;
+}

--- a/libs/core/src/lib/services/managers/polyline-manager.ts
+++ b/libs/core/src/lib/services/managers/polyline-manager.ts
@@ -43,4 +43,8 @@ export abstract class PolylineManager<T = any> {
     eventName: string,
     line: NgMapsPolyline,
   ): Observable<E>;
+
+  public abstract createPathEventObservable(
+    line: NgMapsPolyline,
+  ): Promise<Observable<any>>;
 }

--- a/libs/core/src/public-api.ts
+++ b/libs/core/src/public-api.ts
@@ -10,6 +10,7 @@ export * from './lib/interface/layers';
 export * from './lib/interface/map-options';
 export * from './lib/interface/marker-icon';
 export * from './lib/interface/marker-options';
+export * from './lib/interface/mvc-event';
 export * from './lib/interface/padding';
 export * from './lib/interface/rectangle-options';
 export * from './lib/interface/shape-options';

--- a/libs/google/src/lib/managers/polyline.manager.ts
+++ b/libs/google/src/lib/managers/polyline.manager.ts
@@ -8,6 +8,8 @@ import {
   PolylineManager,
 } from '@ng-maps/core';
 
+import { createMVCEventObservable, MVCEvent } from '../util/mvcarray';
+
 @Injectable()
 export class GooglePolylineManager extends PolylineManager<google.maps.Polyline> {
   constructor(_mapsWrapper: MapsApiWrapper, _zone: NgZone) {
@@ -89,5 +91,23 @@ export class GooglePolylineManager extends PolylineManager<google.maps.Polyline>
         );
       });
     });
+  }
+
+  public async createPathEventObservable(
+    line: NgMapsPolyline,
+  ): Promise<Observable<MVCEvent<google.maps.LatLng>>> {
+    const mvcPath = await this.getMVCPath(line);
+    return createMVCEventObservable(mvcPath);
+  }
+
+  private async getMVCPath(
+    agmPolyline: NgMapsPolyline,
+  ): Promise<google.maps.MVCArray<google.maps.LatLng>> {
+    const polyline = await this._polylines.get(agmPolyline);
+    if (!polyline) {
+      // TODO why???
+      return [] as any as google.maps.MVCArray<google.maps.LatLng>;
+    }
+    return polyline?.getPath();
   }
 }

--- a/libs/google/src/lib/util/mvcarray.ts
+++ b/libs/google/src/lib/util/mvcarray.ts
@@ -1,0 +1,124 @@
+import { fromEventPattern, Observable } from 'rxjs';
+
+import { MVCEvent } from '@ng-maps/core';
+
+export function createMVCEventObservable<T>(
+  array: google.maps.MVCArray<T>,
+): Observable<MVCEvent<T>> {
+  const eventNames = ['insert_at', 'remove_at', 'set_at'];
+  return fromEventPattern(
+    (handler) =>
+      eventNames.map((eventName) =>
+        array.addListener(eventName, (index: number, previous?: T) =>
+          handler.apply(array, [
+            {
+              newArr: array.getArray(),
+              eventName,
+              index,
+              previous,
+            } as MVCEvent<T>,
+          ]),
+        ),
+      ),
+    (_handler, evListeners: Array<google.maps.MapsEventListener>) =>
+      evListeners.forEach((evListener) => evListener.remove()),
+  );
+}
+
+export class MvcArrayMock<T> implements google.maps.MVCArray<T> {
+  private vals: Array<T> = [];
+  private listeners: {
+    remove_at: Array<(i: number, r: T) => void>;
+    insert_at: Array<(i: number) => void>;
+    set_at: Array<(i: number, val: T) => void>;
+  } = {
+    remove_at: [],
+    insert_at: [],
+    set_at: [],
+  };
+  clear(): void {
+    for (let i = this.vals.length - 1; i >= 0; i--) {
+      this.removeAt(i);
+    }
+  }
+  getArray(): Array<T> {
+    return [...this.vals];
+  }
+  getAt(i: number): T {
+    return this.vals[i];
+  }
+  getLength(): number {
+    return this.vals.length;
+  }
+  insertAt(i: number, elem: T): void {
+    this.vals.splice(i, 0, elem);
+    this.listeners.insert_at.forEach((listener) => listener(i));
+  }
+  pop(): T {
+    const deleted = this.vals.pop();
+    if (!deleted) {
+      throw new Error('pop() called on empty array');
+    }
+    this.listeners.remove_at.forEach((listener) =>
+      listener(this.vals.length, deleted),
+    );
+    return deleted;
+  }
+  push(elem: T): number {
+    this.vals.push(elem);
+    this.listeners.insert_at.forEach((listener) =>
+      listener(this.vals.length - 1),
+    );
+    return this.vals.length;
+  }
+  removeAt(i: number): T {
+    const deleted = this.vals.splice(i, 1)[0];
+    this.listeners.remove_at.forEach((listener) => listener(i, deleted));
+    return deleted;
+  }
+  setAt(i: number, elem: T): void {
+    const deleted = this.vals[i];
+    this.vals[i] = elem;
+    this.listeners.set_at.forEach((listener) => listener(i, deleted));
+  }
+  forEach(callback: (elem: T, i: number) => void): void {
+    this.vals.forEach(callback);
+  }
+  addListener(
+    eventName: 'remove_at' | 'insert_at' | 'set_at',
+    handler: (...args: Array<any>) => void,
+  ): google.maps.MapsEventListener {
+    const listenerArr = this.listeners[eventName];
+    listenerArr.push(handler);
+    return {
+      remove: () => {
+        listenerArr.splice(listenerArr.indexOf(handler), 1);
+      },
+    };
+  }
+
+  bindTo(): never {
+    throw new Error('Not implemented');
+  }
+  changed(): never {
+    throw new Error('Not implemented');
+  }
+  get(): never {
+    throw new Error('Not implemented');
+  }
+  notify(): never {
+    throw new Error('Not implemented');
+  }
+  set(): never {
+    throw new Error('Not implemented');
+  }
+  setValues(): never {
+    throw new Error('Not implemented');
+  }
+  unbind(): never {
+    throw new Error('Not implemented');
+  }
+  unbindAll(): never {
+    throw new Error('Not implemented');
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new output event `polyPathChange` for the `NgMapsPolyline` directive to notify changes in the polyline's path.
	- Added a utility function to create observables for Google Maps MVCArray events, enhancing event handling capabilities.

- **Improvements**
	- Expanded the `PolylineManager` and `GooglePolylineManager` classes with new methods for creating path event observables.

- **Public API Updates**
	- Added new interface and type exports related to MVC events, enhancing library usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->